### PR TITLE
Fix typo in Stripe product name

### DIFF
--- a/django_dcmn/orders/views.py
+++ b/django_dcmn/orders/views.py
@@ -138,7 +138,8 @@ class CreateStripeSessionView(APIView):
             description = f"FBI Apostille Order #{order.id} — {order.package}"
         elif order_type == "marriage":
             order = get_object_or_404(MarriageOrder, id=order_id)
-            product_name = f"Tripe Seal Marriage Certificate Deposit"
+            # Corrected typo in product name
+            product_name = "Triple Seal Marriage Certificate Deposit"
             unit_amount = int(order.total_price * 100)
             customer_email = order.email
             description = f"Marriage Certificate Order #{order.id}"


### PR DESCRIPTION
## Summary
- fix product name string for marriage orders in Stripe session

## Testing
- `python django_dcmn/manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_6847e1235f908329927d94f2ff2e7a94